### PR TITLE
Ensure we don't have negative delays

### DIFF
--- a/ESPHome_eink-weatherboard.yaml
+++ b/ESPHome_eink-weatherboard.yaml
@@ -172,8 +172,8 @@ script:
       - if:  # with longer sleep delays, the ESP32 tends to wake up a bit too early... if the wake time is within the next 8 minutes, wait for the scheduled wake time (less 30s) (preventing it from updating twice in a row)
           condition:
             lambda: 'return (id(wake_time_helper).state <= (8 * 60));'
-          then:
-            - delay: !lambda 'return (((id(wake_time_helper).state) - 30) * 1000);'
+          then: # if our calculated delay for waking is less than 0, then set it to 0 (to prevent negative delay)
+            - delay: !lambda 'return (((id(wake_time_helper).state - 30) < 0 ? 0 : (id(wake_time_helper).state - 30)) * 1000);'
       - if:
           condition:
             lambda: 'return id(data_updated) == true;'


### PR DESCRIPTION
In certain scenarios, if we wake up too early (or right at 0 seconds left till we're supposed to wake up), the logic that would cause a delay to wait until the appropriate wake up time could calculate into a negative value.
This is a quick and dirty check to ensure we don't have negative delay times, and if we do, then set the delay to 0.

Resolves: https://github.com/trip5/ESPHome-eInk-Boards/issues/4
